### PR TITLE
Update ODBC Driver Download Links

### DIFF
--- a/_artifacts/opensearch-drivers/opensearch-odbc-1.5.0.0-macos-x64.markdown
+++ b/_artifacts/opensearch-drivers/opensearch-odbc-1.5.0.0-macos-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: driver
+artifact_id: opensearch-sql-odbc
+version: 1.5.0.0
+platform: macos
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg
+slug: opensearch-sql-odbc-mac-1.5.0.0
+category: opensearch
+type: pkg
+code_signer: true
+---

--- a/_artifacts/opensearch-drivers/opensearch-odbc-1.5.0.0-windows-x32.markdown
+++ b/_artifacts/opensearch-drivers/opensearch-odbc-1.5.0.0-windows-x32.markdown
@@ -1,0 +1,12 @@
+---
+role: driver
+artifact_id: opensearch-sql-odbc
+version: 1.5.0.0
+platform: windows
+architecture: x86
+artifact_url: https://artifacts.opensearch.org/opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi
+slug: opensearch-sql-odbc-win32-1.5.0.0
+category: opensearch
+type: msi
+windows_signer: true
+---

--- a/_artifacts/opensearch-drivers/opensearch-odbc-1.5.0.0-windows-x64.markdown
+++ b/_artifacts/opensearch-drivers/opensearch-odbc-1.5.0.0-windows-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: driver
+artifact_id: opensearch-sql-odbc
+version: 1.5.0.0
+platform: windows
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi
+slug: opensearch-sql-odbc-win64-1.5.0.0
+category: opensearch
+type: msi
+windows_signer: true
+---

--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -245,7 +245,7 @@ this is the built-in error checking for the version definition having missing ar
             {% if details.signature %}
               {% capture artifact_extra %}
                 <div class="extra_links extra_{{artifact_id}}"> <a href="{{details.signature}}"> {{signature_pretty}} </a>
-                <a href="/verify-signatures.html">Signature verification how to</a></div>
+                <a href="/verify-signatures.html#Pgp">Signature verification how to</a></div>
               {% endcapture %}
               {% assign artifact_extras = artifact_extras | append: artifact_extra %}
             {% endif %}
@@ -253,6 +253,20 @@ this is the built-in error checking for the version definition having missing ar
               {% capture artifact_extra %}
                 <div class="extra_links extra_{{artifact_id}}">
                 <a href="/verify-signatures.html#JarSigner">Signature verification how to</a></div>
+              {% endcapture %}
+              {% assign artifact_extras = artifact_extras | append: artifact_extra %}
+            {% endif %}
+            {% if details.code_signer %}
+              {% capture artifact_extra %}
+                <div class="extra_links extra_{{artifact_id}}">
+                  <a href="/verify-signatures.html#CodeSigner">Signature verification how to</a></div>
+              {% endcapture %}
+              {% assign artifact_extras = artifact_extras | append: artifact_extra %}
+            {% endif %}
+            {% if details.windows_signer %}
+              {% capture artifact_extra %}
+                <div class="extra_links extra_{{artifact_id}}">
+                  <a href="/verify-signatures.html#WindowsSigner">Signature verification how to</a></div>
               {% endcapture %}
               {% assign artifact_extras = artifact_extras | append: artifact_extra %}
             {% endif %}

--- a/_versions/2023-06-06-opensearch-2.8.0.markdown
+++ b/_versions/2023-06-06-opensearch-2.8.0.markdown
@@ -31,7 +31,7 @@ components:
     version: 2.8.0
   - role: drivers
     artifact: opensearch-sql-odbc
-    version: 1.1.0.1
+    version: 1.5.0.0
   - role: drivers
     artifact: opensearch-sql-jdbc
     version: 1.3.0.0

--- a/verify-signatures.markdown
+++ b/verify-signatures.markdown
@@ -6,7 +6,7 @@ title: How to verify signatures
 
 ## How to verify signatures for downloadable artifacts
 
-### PGP
+### <a name="Pgp">PGP</a>
 Download our PGP key using the link below and import it. 
 
 If you’re using gpg, you just need to run: 
@@ -34,6 +34,40 @@ Only the JDBC driver is signed with JarSigner.
 To verify signature run in the terminal:
 ```
 jarsigner -verify -verbose <path_to_jar>
+```
+
+### <a name="WindowsSigner">Windows</a>
+ODBC driver .msi can be verified by a few different methods.
+
+Verify signature in PowerShell version > 5.1:
+```
+Get-AuthenticodeSignature -FilePath <path_to_msi>
+```
+
+Verify signature using SigCheck:
+
+- Download [SigCheck](https://learn.microsoft.com/en-us/sysinternals/downloads/sigcheck)
+
+Verify signature using SignTool:
+
+- Download [SignTool](https://learn.microsoft.com/en-us/windows/win32/seccrypto/using-signtool-to-verify-a-file-signature)
+
+Signature Certificate:
+```
+2DA2 DC02 8EE6 42CD 77C4 BA04 F289 1F24 7831 2C29
+```
+
+### <a name="CodeSigner">CodeSign</a>
+ODBC driver .pkg is signed using CodeSign.
+
+To verify signature run in the terminal:
+```
+pkgutil --verbose --check-signature <path_to_pkg>
+```
+
+Certificate Fingerprint:
+```
+49 68 39 4A BA 83 3B F0 CC 5E 98 3B E7 C1 72 AC 85 97 65 18 B9 4C BA 34 62 BF E9 23 76 98 C5 DA
 ```
 
 ## Change Log ##

--- a/verify-signatures.markdown
+++ b/verify-signatures.markdown
@@ -52,13 +52,13 @@ Verify signature using SignTool:
 
 - Download [SignTool](https://learn.microsoft.com/en-us/windows/win32/seccrypto/using-signtool-to-verify-a-file-signature)
 
-Signature Certificate:
+Signature Fingerprint:
 ```
 2DA2 DC02 8EE6 42CD 77C4 BA04 F289 1F24 7831 2C29
 ```
 
 ### <a name="CodeSigner">CodeSign</a>
-ODBC driver .pkg is signed using CodeSign.
+Signature of ODBC driver installer for MacOS could be verified using `pgkutil`.
 
 To verify signature run in the terminal:
 ```
@@ -74,10 +74,11 @@ Certificate Fingerprint:
 
 <div class="table-styler"></div>
 
-| Date         | Issue | Created | Expires |
-|:-------------|:-------|:----------------|:----------------|
-| 2022-05-11  | [Issue 2040](https://github.com/opensearch-project/opensearch-build/issues/2040){:target="_blank"}  | 2022-05-12 | 2023-05-12 |
-| 2023-05-04  | [Issue 2136](https://github.com/opensearch-project/opensearch-build/issues/2136){:target="_blank"}  | 2023-05-03 | 2024-05-12 |
-| 2023-06-21  | [Issue 97](https://github.com/opensearch-project/sql-jdbc/issues/97){:target="_blank"}  | 2023-04-13 | 2031-11-09 |
+| Date       | Issue | Created    | Expires    |
+|:-----------|:-------|:-----------|:-----------|
+| 2022-05-11 | [Issue 2040](https://github.com/opensearch-project/opensearch-build/issues/2040){:target="_blank"}  | 2022-05-12 | 2023-05-12 |
+| 2023-05-04 | [Issue 2136](https://github.com/opensearch-project/opensearch-build/issues/2136){:target="_blank"}  | 2023-05-03 | 2024-05-12 |
+| 2023-06-21 | [Issue 97](https://github.com/opensearch-project/sql-jdbc/issues/97){:target="_blank"}  | 2023-04-13 | 2031-11-09 |
+| 2023-07-17 | [Issue 3633](https://github.com/opensearch-project/opensearch-build/issues/3633){:target="_blank"}  | 2023-07-05 | 2027-06-28 |
 
 <br>


### PR DESCRIPTION
### Description
Update ODBC download links for version 1.5.0.0. Added signature verification how to links for MacOS and Windows Builds.
 
 
<img width="1350" alt="signers_screenshot" src="https://github.com/Bit-Quill/project-website/assets/36905077/7709537c-beec-479d-b0ff-1d879c297f41">

<img width="1070" alt="drivers-pic" src="https://github.com/Bit-Quill/project-website/assets/36905077/9ebb7d00-ad35-49aa-9171-2ac7f85335f9">

 
[Opensearch 2.8.0 · OpenSearch.pdf](https://github.com/Bit-Quill/project-website/files/12044946/Opensearch.2.8.0.OpenSearch.pdf)

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
